### PR TITLE
Support appending to arrays

### DIFF
--- a/library/k8s_json_patch.py
+++ b/library/k8s_json_patch.py
@@ -129,6 +129,10 @@ def resolve_path(obj, path):
         key = unmatched_path.pop(0)
         context = value
         value = None
+        if key == '-' and isinstance(context, list):
+            unmatched_path.insert(0, str(len(context)))
+            break
+
         if isinstance(context, dict):
             if key in context:
                 matched_path.append(key)


### PR DESCRIPTION
http://jsonpatch.com/#add
> The `-` character can be used instead of an index to insert at the end of an array.

Currently attempting to append to an array using an `add` op with this module fails as `-` isn't a valid index. This change causes `_process_patch_add` to be invoked, appending the desired value to the array.